### PR TITLE
Improve punctuation removal

### DIFF
--- a/utils/conll2ull.py
+++ b/utils/conll2ull.py
@@ -90,7 +90,7 @@ def main(argv):
                             mapping = [i for i in range(len(sentence))]
 
                         # Only print sentences within desired length
-                        if tagged_len <= max_length:
+                        if 0 < tagged_len <= max_length:
                             links = create_links(tagged_sent, mapping, link_ids)
                             clean_sent = [word for word in tagged_sent[1:] if word != IGNORED_WORD]
                             fc.write(" ".join(clean_sent) + "\n\n")  # print to corpus file

--- a/utils/conll2ull.py
+++ b/utils/conll2ull.py
@@ -53,16 +53,16 @@ def main(argv):
     """
     Transforms dependency parses in CoNLL format to ULL format
 
-    Usage: python conll2ull.py <conll_filepath> <punct_flag> <max_length> <lower_caps>
+    Usage: python conll2ull.py <dirpath> <punct_flag> <max_length> <lower_caps>
 
-    conll_filepath:     (str) Filepath to CONLL file
+    dirpath:            (str) Directory path with CONLL files
     punct_flag:         (int) Boolean flag to remove or not remove punctuation
     max_length:         (int) Ignore sentences longer than this parameter, after punctuation removal
     lower_caps:         (int) Boolean flag to convert to lowercaps
     """
 
     if len(argv) < 4:
-        print("Usage: python conll2ull.py <conll_filepath> <punct_flag> <max_length>")
+        print("Usage: python conll2ull.py <dirpath> <punct_flag> <max_length>")
 
     dirpath = argv[0]
     punct_flag = bool(int(argv[1]))  # Flag to remove punctuation

--- a/utils/conll2ull.py
+++ b/utils/conll2ull.py
@@ -50,19 +50,21 @@ def main(argv):
     """
     Transforms dependency parses in CoNLL format to ULL format
 
-    Usage: python conll2ull.py <conll_filepath> <punct_flag> <max_length>
+    Usage: python conll2ull.py <conll_filepath> <punct_flag> <max_length> <lower_caps>
 
     conll_filepath:     (str) Filepath to CONLL file
     punct_flag:         (int) Boolean flag to remove or not remove punctuation
     max_length:         (int) Ignore sentences longer than this parameter, after punctuation removal
+    lower_caps:         (int) Boolean flag to convert to lowercaps
     """
 
-    if len(argv) < 3:
+    if len(argv) < 4:
         print("Usage: python conll2ull.py <conll_filepath> <punct_flag> <max_length>")
 
     conll_filename = argv[0]
     punct_flag = bool(int(argv[1]))  # Flag to remove punctuation
     max_length = int(argv[2])  # max length of sentences to process after punctuation removal (if any)
+    lower_caps = bool(int(argv[3]))  # Flag to convert to lowercaps
     print(f"\nProcessing file {conll_filename}\npunct_flag={punct_flag}\nmax_length={max_length}\n")
 
     num_parses = 0  # num of parses in output file
@@ -71,7 +73,7 @@ def main(argv):
     links = []
 
     with open(conll_filename, 'r') as fi:
-        with open(argv[0] + ".ull", 'w') as fo:
+        with open(argv[0] + ".txt.ull", 'w') as fo:
             with open(argv[0] + ".txt", 'w') as fc:
                 lines = fi.readlines()
                 for line in lines:
@@ -99,6 +101,8 @@ def main(argv):
 
                     # Links are still being processed
                     else:
+                        if lower_caps:
+                            line = line.lower()
                         split_line = line.split('\t')
                         link_ids.append([int(split_line[6]), int(split_line[0])])  # store links indexes
                         sentence.append(split_line[1])  # build sentence array

--- a/utils/conll2ull.py
+++ b/utils/conll2ull.py
@@ -4,6 +4,7 @@
 
 import sys
 import re
+import string
 
 ROOT_WORD = "###LEFT-WALL###"
 IGNORED_WORD = "###PUNCTUATION###"
@@ -12,15 +13,17 @@ IGNORED_FLAG = -1
 
 def tag_punctuation(sentence):
     """
-    Tag every word that doesn't contain an alphanumeric character
+    Remove punctuation, and tag every token that only contains punctuation
     """
     tagged_sentence = []
     tagged_len = -1  # start negative to avoid counting the ROOT_WORD
     mapping = []
     num_punctuations = 0  # count how many tokens are punctuation
+    translator = str.maketrans('', '', string.punctuation)  # create translation table
     for cnt, word in enumerate(sentence):
-        if bool(re.match('.*[A-Za-z0-9]', word)):
-            tagged_sentence.append(word)
+        new_word = word.translate(translator)
+        if len(new_word) > 0:
+            tagged_sentence.append(new_word)
             mapping.append(cnt - num_punctuations)
             tagged_len += 1
         else:

--- a/utils/conll2ull.py
+++ b/utils/conll2ull.py
@@ -15,18 +15,19 @@ def tag_punctuation(sentence):
     """
     Remove punctuation, and tag every token that only contains punctuation
     """
-    tagged_sentence = []
-    tagged_len = -1  # start negative to avoid counting the ROOT_WORD
-    mapping = []
+    tagged_len = 0
     num_punctuations = 0  # count how many tokens are punctuation
+    tagged_sentence = [sentence[0]]  # keep punctuation in ROOT_WORD
+    mapping = [0]
     translator = str.maketrans('', '', string.punctuation)  # create translation table
-    for cnt, word in enumerate(sentence):
+
+    for cnt, word in enumerate(sentence[1:]):
         new_word = word.translate(translator)
-        if len(new_word) > 0:
+        if len(new_word) > 0:  # token that contains non-punctuation characters
             tagged_sentence.append(new_word)
-            mapping.append(cnt - num_punctuations)
+            mapping.append(cnt + 1 - num_punctuations)
             tagged_len += 1
-        else:
+        else:  # removed all chars from token
             tagged_sentence.append(IGNORED_WORD)
             num_punctuations += 1
             mapping.append(IGNORED_FLAG)
@@ -76,7 +77,7 @@ def main(argv):
     sentence = [ROOT_WORD]
     link_ids = []
 
-    newdir = dirpath + '_ull_' + punct_str + str(max_length) + lower_str + '/'
+    newdir = dirpath + '_ull_' + punct_str + '_' + str(max_length) + '_' + lower_str + '/'
     os.mkdir(newdir)
     os.mkdir(newdir + 'GS')
     os.mkdir(newdir + 'corpus')
@@ -117,7 +118,7 @@ def main(argv):
                                 link_ids.append([int(split_line[6]), int(split_line[0])])  # store links indexes
                                 sentence.append(split_line[1])  # build sentence array
 
-    print(f"Converted {num_parses} parses with len <= {max_length}")
+        print(f"Converted {num_parses} parses with len <= {max_length}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Changed the way in which punctuation removal happens.
The new method relies on characters in python's string.punctuation.
Any token which contains only characters in this set is considered punctuation and removed from the sentence.